### PR TITLE
Validate uniqueness of names in sequences

### DIFF
--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -11,6 +11,7 @@ class Sequence < ActiveRecord::Base
   COLORS = %w(blue green yellow orange purple pink gray red)
   validates :name, presence: true
   validates_inclusion_of :color, in: COLORS
+  validates_uniqueness_of :name, scope: :device
 
   # http://stackoverflow.com/a/5127684/1064917
   after_initialize :init

--- a/app/mutations/sequences/update.rb
+++ b/app/mutations/sequences/update.rb
@@ -32,8 +32,23 @@ module Sequences
       sequence
 
       rescue ActiveRecord::RecordInvalid => e
-        offender = e.record.as_json.slice("message_type", "position").to_s
-        add_error :steps,
+        case e.record
+        when Sequence
+          bad_sequence(e)
+        when Step
+          bad_step(e)
+        else
+          add_error :other, :unknown, (e.try(:message) || "Unknown validation issues.")
+        end
+    end
+
+    def bad_sequence(e)
+      add_error :sequence, :not_valid, e.message
+    end
+
+    def bad_step(e)
+      offender = e.record.as_json.slice("message_type", "position").to_s
+      add_error :steps,
                 :probably_bad,
                 "Failed to instantiate nested step. Offending item: " + offender
     end

--- a/spec/models/sequence_spec.rb
+++ b/spec/models/sequence_spec.rb
@@ -1,3 +1,14 @@
+require 'spec_helper'
+describe Sequence do
+  let(:regimen) { FactoryGirl.create(:regimen) }
 
-RSpec.describe Sequence, :type => :model do
+  it "Enforces uniqueness of names" do
+
+    optns = { device: regimen.device,
+                name: "Dupe",
+                color: "red" }
+    Sequence.create!(optns)
+    expect { Sequence.create!(optns) }.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
 end

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -1,3 +1,0 @@
-
-RSpec.describe Step, :type => :model do
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,5 +51,6 @@ RSpec.configure do |config|
 
   config.after(:suite) do
     SmarfDoc.finish!
+    ActiveRecord::Base.subclasses.map(&:delete_all)
   end
 end


### PR DESCRIPTION
# What's New?

 * Disallow sequences with the same name
 * Helpful error messages in sequence editor if you try to make dupes.

# What's Next?

 * Persist webcam feed URL.
 