### PR TITLE
20 December

### DIFF
--- a/app/lib/celery_script/argument_specification.rb
+++ b/app/lib/celery_script/argument_specification.rb
@@ -1,0 +1,26 @@
+module CeleryScript
+  class ArgumentSpecification
+    attr_reader :name, :allowed_values, :additional_validation
+    NOOP = ->(_, __) { }
+
+    def initialize(name, allowed_values, additional_validation = NOOP)
+      @name                  = name
+      @allowed_values        = allowed_values
+      @additional_validation = additional_validation
+    end
+
+    # PROBLEM: Ruby calls them "Fixnum"s, but the world calls them "integers"
+    # SOLUTION: Add a dictionary of special rules.
+    def serialize_allowed_value(v)
+      { String => "string",
+        Fixnum => "integer" }[v] || v
+    end
+
+    def as_json(optns)
+      {
+        "name"           => name,
+        "allowed_values" => allowed_values.map { |av| serialize_allowed_value(av) }
+      }
+    end
+  end
+end

--- a/app/lib/celery_script/argument_specification.rb
+++ b/app/lib/celery_script/argument_specification.rb
@@ -1,7 +1,7 @@
 module CeleryScript
+  NOOP = ->(*_) { }
   class ArgumentSpecification
     attr_reader :name, :allowed_values, :additional_validation
-    NOOP = ->(_, __) { }
 
     def initialize(name, allowed_values, additional_validation = NOOP)
       @name                  = name

--- a/app/lib/celery_script/ast_base.rb
+++ b/app/lib/celery_script/ast_base.rb
@@ -1,0 +1,9 @@
+module CeleryScript
+  # Abstract class that AstLeaf and AstNode inherit from.
+  # Use this for shared leaf/node behavior.
+  class AstBase
+    def invalidate!(message = "Unspecified type check error.")
+      raise CeleryScript::TypeCheckError, message
+    end
+  end
+end

--- a/app/lib/celery_script/ast_leaf.rb
+++ b/app/lib/celery_script/ast_leaf.rb
@@ -1,0 +1,8 @@
+module CeleryScript
+  class AstLeaf < AstBase
+    attr_reader :kind, :value, :parent
+    def initialize(parent, value, kind)
+      @parent, @value, @kind = parent, value, kind
+    end
+  end
+end

--- a/app/lib/celery_script/ast_node.rb
+++ b/app/lib/celery_script/ast_node.rb
@@ -1,18 +1,5 @@
 module CeleryScript
-  class AbstractNode
-    def invalidate!(message = "Unspecified type check error.")
-      raise CeleryScript::TypeCheckError, message
-    end
-  end
-
-  class AstLeaf < AbstractNode
-    attr_reader :kind, :value, :parent
-    def initialize(parent, value, kind)
-      @parent, @value, @kind = parent, value, kind
-    end
-  end
-
-  class AstNode < AbstractNode
+  class AstNode < AstBase
       attr_reader :args, :body, :comment, :kind, :parent
       BODY_HAS_NON_NODES = "The `body` of a node can only contain nodes- " \
                            "no leaves here."
@@ -47,7 +34,7 @@ module CeleryScript
         (hash[:body].is_a?(Array) || hash[:body] == nil) &&
         (hash[:comment].is_a?(String) || hash[:comment] == nil) &&
         (hash[:args].is_a?(Hash)) &&
-        (hash[:kind].is_a?(String))      
+        (hash[:kind].is_a?(String))
       end
   end
 end

--- a/app/lib/celery_script/checker.rb
+++ b/app/lib/celery_script/checker.rb
@@ -38,15 +38,11 @@ module CeleryScript
 
     def validate_body(node)
       (node.body || []).each_with_index do |inner_node, i|
-        if inner_node.is_a?(AstNode)
-          allowed = corpus.fetchNode(node.kind).allowed_body_types
-          body_ok = Array(allowed)
-                      .map(&:to_sym)
-                      .include?(inner_node.kind.to_sym)
-          bad_body_kind(node, inner_node, i, allowed) unless body_ok
-        else
-          leaf_in_body(node, i)
-        end
+        allowed = corpus.fetchNode(node.kind).allowed_body_types
+        body_ok = Array(allowed)
+                    .map(&:to_sym)
+                    .include?(inner_node.kind.to_sym)
+        bad_body_kind(node, inner_node, i, allowed) unless body_ok
       end
     end
 
@@ -107,11 +103,6 @@ module CeleryScript
     def bad_body_kind(prnt, child, i, ok)
       m = "Body of `#{prnt.kind}` node contains `#{child.kind}` node. It may "\
           "only contain: #{ok.inspect}"
-      raise TypeCheckError, m
-    end
-
-    def leaf_in_body(parent, i)
-      m = "Body item ##{i} in '#{parent.kind}' node is not a valid AstNode."
       raise TypeCheckError, m
     end
   end

--- a/app/lib/celery_script/corpus.rb
+++ b/app/lib/celery_script/corpus.rb
@@ -1,39 +1,4 @@
 module CeleryScript
-  class ArgumentSpecification
-    attr_reader :name, :allowed_values, :additional_validation
-    NOOP = ->(_, __) { }
-
-    def initialize(name, allowed_values, additional_validation = NOOP)
-      @name                  = name
-      @allowed_values        = allowed_values
-      @additional_validation = additional_validation
-    end
-
-    # PROBLEM: Ruby calls them "Fixnum"s, but the world calls them "integers"
-    # SOLUTION: Add a dictionary of special rules.
-    def serialize_allowed_value(v)
-      { String => "string",
-        Fixnum => "integer" }[v] || v
-    end
-
-    def as_json(optns)
-      {
-        "name"           => name,
-        "allowed_values" => allowed_values.map { |av| serialize_allowed_value(av) }
-      }
-    end
-  end
-
-  class NodeSpecification
-    attr_reader :name, :allowed_args, :allowed_body_types
-
-    def initialize(name, allowed_args, allowed_body_types)
-      @name                  = name
-      @allowed_args          = allowed_args
-      @allowed_body_types    = allowed_body_types
-    end
-  end
-
   class Corpus
     BAD_NODE_NAME = "Can't find validation rules for node "
     NO_ARG_SPEC   = "CANT FIND ARG SPEC"

--- a/app/lib/celery_script/corpus.rb
+++ b/app/lib/celery_script/corpus.rb
@@ -30,6 +30,21 @@ module CeleryScript
       self
     end
 
+    # List of allowed arg types for a node.
+    def args(node)
+      fetchNode(node.kind).allowed_args
+    end
+
+    # List of allowed values for a node
+    def values(node)
+      fetchArg(node.kind).allowed_values
+    end
+
+    # List of allowed body node types within a node
+    def bodies(node)
+      Array(fetchNode(node.kind).allowed_body_types).map(&:to_sym)
+    end
+
     def as_json(optns)
       { "tag": SequenceMigration::Base.latest_version,
         "args": @arg_def_list.to_a.map(&:last).map{|x| x.as_json({}) },

--- a/app/lib/celery_script/corpus.rb
+++ b/app/lib/celery_script/corpus.rb
@@ -36,25 +36,23 @@ module CeleryScript
 
   class Corpus
     BAD_NODE_NAME = "Can't find validation rules for node "
-
+    NO_ARG_SPEC   = "CANT FIND ARG SPEC"
     def initialize
       @arg_def_list = {}
       @node_def_list = {}
     end
 
     def fetchArg(name)
-      @arg_def_list[name.to_sym] or raise "CANT FIND ARG SPEC"
+      @arg_def_list[name.to_sym] or raise NO_ARG_SPEC
     end
 
     def defineArg(arg_name, allowed_values, &blk)
-    #   additional_checks.call("node", "err_callback")
       @arg_def_list[arg_name.to_sym] = ArgumentSpecification.new(arg_name,
                                                                  allowed_values,
                                                                  blk)
       self
     end
 
-    #TODO : These names are all JS case! Use snake case in Ruby.
     def fetchNode(name)
       n = @node_def_list[name.to_sym]
       n ? n : raise(TypeCheckError, BAD_NODE_NAME + name.to_s)

--- a/app/lib/celery_script/corpus.rb
+++ b/app/lib/celery_script/corpus.rb
@@ -2,6 +2,7 @@ module CeleryScript
   class Corpus
     BAD_NODE_NAME = "Can't find validation rules for node "
     NO_ARG_SPEC   = "CANT FIND ARG SPEC"
+
     def initialize
       @arg_def_list = {}
       @node_def_list = {}
@@ -43,6 +44,10 @@ module CeleryScript
     # List of allowed body node types within a node
     def bodies(node)
       Array(fetchNode(node.kind).allowed_body_types).map(&:to_sym)
+    end
+
+    def validator(name)
+      fetchArg(name).additional_validation || CeleryScript::NOOP
     end
 
     def as_json(optns)

--- a/app/lib/celery_script/node_specification.rb
+++ b/app/lib/celery_script/node_specification.rb
@@ -1,0 +1,11 @@
+module CeleryScript
+  class NodeSpecification
+    attr_reader :name, :allowed_args, :allowed_body_types
+
+    def initialize(name, allowed_args, allowed_body_types)
+      @name                  = name
+      @allowed_args          = allowed_args
+      @allowed_body_types    = allowed_body_types
+    end
+  end
+end

--- a/app/lib/sequence_migration.rb
+++ b/app/lib/sequence_migration.rb
@@ -11,7 +11,8 @@ module SequenceMigration
     def self.descendants
       [
         AddVersionInfo,
-        UpdateChannelNames
+        UpdateChannelNames,
+        AddToolsToMoveAbs
       ]
     end
 

--- a/app/lib/sequence_migration/add_tools_to_move_abs.rb
+++ b/app/lib/sequence_migration/add_tools_to_move_abs.rb
@@ -1,0 +1,22 @@
+module SequenceMigration
+  # Background:
+  # When this migration was created, the move_absolute block could only move to
+  # a fixed point on the map.
+  # After this migration, the user could move to a dynamically set tool location
+  # -OR- a fixed point on the map.
+  class AddToolsToMoveAbs < Base
+    VERSION = 2
+    CREATED_ON = "DECEMBER 19 2016"
+
+    def up
+      sequence
+        .body
+        .select { |x| x["kind"] == "move_absolute" }
+        .each   do |x|
+          loc = { "kind" => "coordinate" }.merge(x["args"].slice("x", "y", "z"))
+          x["args"]["location"] = loc
+          x["args"].except!("x", "y", "z")
+        end
+    end
+  end
+end

--- a/app/models/celery_script_settings_bag.rb
+++ b/app/models/celery_script_settings_bag.rb
@@ -11,46 +11,50 @@ module CeleryScriptSettingsBag
                              send_message execute if_statement)
   ALLOWED_LHS           = %w(busy pin0 pin1 pin2 pin3 pin4 pin5 pin6 pin7 pin8
                              pin9 pin10 pin11 pin12 pin13 x y z)
+  BAD_ALLOWED_PIN_MODES = 'Can not put "%s" into a left hand side (LHS) '\
+                          'argument. Allowed values: %s'
+  BAD_LHS               = 'Can not put "%s" into a left hand side (LHS) '\
+                          'argument. Allowed values: %s'
+  BAD_SUB_SEQ           = 'Sequence #%s does not exist.'
+  BAD_OP                = 'Can not put "%s" into an operand (OP) argument. '\
+                          'Allowed values: %s'
+  BAD_CHANNEL_NAME      = '"%s" is not a valid channel_name. Allowed values: %s'
+  BAD_MESSAGE_TYPE      = '"%s" is not a valid message_type. Allowed values: %s'
+  BAD_TOOL_ID           = 'Tool #%s does not exist.'
 
   Corpus = CeleryScript::Corpus
       .new
       .defineArg(:pin_mode,        [Fixnum]) do |node|
         within(ALLOWED_PIN_MODES, node) do |val|
-          "Can not put \"#{ val.to_s }\" into a left hand side (LHS)"\
-          " argument. Allowed values: #{ALLOWED_LHS.map(&:to_s).join(", ")}"
+          BAD_ALLOWED_PIN_MODES % [val.to_s, ALLOWED_LHS.inspect]
         end
       end
       .defineArg(:sub_sequence_id, [Fixnum]) do |node|
         missing = !Sequence.exists?(node.value)
-        node.invalidate!("Sequence ##{ node.value } does not exist.") if missing
+        node.invalidate!(BAD_SUB_SEQ % [node.value]) if missing
       end
       .defineArg(:lhs,             [String]) do |node|
         within(ALLOWED_LHS, node) do |val|
-          "Can not put \"#{ val.to_s }\" into a left hand side (LHS)"\
-          " argument. Allowed values: #{ALLOWED_LHS.map(&:to_s).join(", ")}"
+          BAD_LHS % [val.to_s, ALLOWED_LHS.inspect]
         end
       end
       .defineArg(:op,              [String]) do |node|
         within(ALLOWED_OPS, node) do |val|
-          "Can not put \"#{ val.to_s }\" into an operand (OP)"\
-          " argument. Allowed values: #{ALLOWED_OPS.map(&:to_s).join(", ")}"
+          BAD_OP % [val.to_s, ALLOWED_OPS.inspect]
         end
       end
       .defineArg(:channel_name,    [String]) do |node|
         within(ALLOWED_CHANNEL_NAMES, node) do |val|
-          "\"#{ val.to_s }\" is not a valid channel_name. " \
-          "Allowed values: #{ALLOWED_CHANNEL_NAMES.map(&:to_s).join(", ")}"
+          BAD_CHANNEL_NAME %  [val.to_s, ALLOWED_CHANNEL_NAMES.inspect]
         end
       end
       .defineArg(:message_type,    [String]) do |node|
         within(ALLOWED_MESSAGE_TYPES, node) do |val|
-          "\"#{ val.to_s }\" is not a valid message_type. " \
-          "Allowed values: #{ALLOWED_MESSAGE_TYPES.map(&:to_s).join(", ")}"
+          BAD_MESSAGE_TYPE % [val.to_s, ALLOWED_MESSAGE_TYPES.inspect]
         end
       end
       .defineArg(:tool_id,         [Fixnum]) do |node|
-        missing = !Tool.exists?(node.value)
-        node.invalidate!("Tool ##{ node.value } does not exist.") if missing
+        node.invalidate!(BAD_TOOL_ID % node.value) if !Tool.exists?(node.value)
       end
       .defineArg(:version,         [Fixnum])
       .defineArg(:x,               [Fixnum])

--- a/app/models/celery_script_settings_bag.rb
+++ b/app/models/celery_script_settings_bag.rb
@@ -7,10 +7,10 @@ module CeleryScriptSettingsBag
   ALLOWED_CHANNEL_NAMES = %w(ticker toast)
   ALLOWED_DATA_TYPES    = %w(string integer)
   ALLOWED_OPS           = %w(< > is not)
-  STEPS = %w(move_absolute move_relative write_pin read_pin wait send_message
-             execute if_statement)
-  ALLOWED_LHS = %w(busy pin0 pin1 pin2 pin3 pin4 pin5 pin6 pin7 pin8 pin9 pin10
-                   pin11 pin12 pin13 x y z)
+  STEPS                 = %w(move_absolute move_relative write_pin read_pin wait
+                             send_message execute if_statement)
+  ALLOWED_LHS           = %w(busy pin0 pin1 pin2 pin3 pin4 pin5 pin6 pin7 pin8
+                             pin9 pin10 pin11 pin12 pin13 x y z)
 
   Corpus = CeleryScript::Corpus
       .new
@@ -48,6 +48,10 @@ module CeleryScriptSettingsBag
           "Allowed values: #{ALLOWED_MESSAGE_TYPES.map(&:to_s).join(", ")}"
         end
       end
+      .defineArg(:tool_id,         [Fixnum]) do |node|
+        missing = !Tool.exists?(node.value)
+        node.invalidate!("Tool ##{ node.value } does not exist.") if missing
+      end
       .defineArg(:version,         [Fixnum])
       .defineArg(:x,               [Fixnum])
       .defineArg(:y,               [Fixnum])
@@ -59,7 +63,10 @@ module CeleryScriptSettingsBag
       .defineArg(:rhs,             [Fixnum])
       .defineArg(:data_label,      [String])
       .defineArg(:message,         [String])
-      .defineNode(:move_absolute,  [:x, :y, :z, :speed])
+      .defineArg(:location,        [String])
+      .defineNode(:tool,           [:tool_id])
+      .defineNode(:coordinate,     [:x, :y, :z])
+      .defineNode(:move_absolute,  [:location, :speed])
       .defineNode(:move_relative,  [:x, :y, :z, :speed])
       .defineNode(:write_pin,      [:pin_number, :pin_value, :pin_mode ])
       .defineNode(:read_pin,       [:pin_number, :data_label, :pin_mode])

--- a/app/models/celery_script_settings_bag.rb
+++ b/app/models/celery_script_settings_bag.rb
@@ -67,7 +67,7 @@ module CeleryScriptSettingsBag
       .defineArg(:rhs,             [Fixnum])
       .defineArg(:data_label,      [String])
       .defineArg(:message,         [String])
-      .defineArg(:location,        [String])
+      .defineArg(:location,        [:tool, :coordinate])
       .defineNode(:tool,           [:tool_id])
       .defineNode(:coordinate,     [:x, :y, :z])
       .defineNode(:move_absolute,  [:location, :speed])

--- a/spec/lib/celery_script/ast_fixture3.json
+++ b/spec/lib/celery_script/ast_fixture3.json
@@ -8,9 +8,26 @@
         {
             "kind": "move_absolute",
             "args": {
-                "x": 1,
-                "y": 2,
-                "z": 3,
+                "location": {
+                    "kind": "coordinate",
+                    "args": {
+                        "x": 1,
+                        "y": 2,
+                        "z": 3
+                    }
+                },
+                "speed": 4
+            }
+        },
+        {
+            "kind": "move_absolute",
+            "args": {
+                "location": {
+                    "kind": "tool",
+                    "args": {
+                        "tool_id": 1
+                    }
+                },
                 "speed": 4
             }
         },

--- a/spec/lib/celery_script/body_spec.rb
+++ b/spec/lib/celery_script/body_spec.rb
@@ -25,7 +25,7 @@ describe "Body nodes" do
     checker = CeleryScript::Checker.new(tree, test_corpus)
     expect(checker.valid?).to eq(false)
     expect(checker.error.message).to include(
-      "node contains `wrong` node"
+      "node contains 'wrong' node"
     )
   end
 

--- a/spec/lib/celery_script/body_spec.rb
+++ b/spec/lib/celery_script/body_spec.rb
@@ -27,13 +27,31 @@ describe "Body nodes" do
     expect(checker.error.message).to include("node contains 'wrong' node")
   end
 
+  it "handles body members of nodes that shouldn't have bodies." do
+    tree = CeleryScript::AstNode.new({
+      "kind": "baz",
+      "args": {},
+      "body": [{ "kind": "wrong", "args": {}}]
+    })
+    checker = CeleryScript::Checker.new(tree, test_corpus)
+    expect(checker.valid?).to eq(false)
+    expect(checker.error.message).to include("node contains 'wrong' node")
+  end
+
   it 'disallows leaves in the body field of a node' do
-    expect do
-      CeleryScript::AstNode.new({
-        "kind": "baz",
+    tree = CeleryScript::AstNode.new({
+        "kind": "wrong",
         "args": {},
-        "body": ["wrong"]
+        "body": [
+          {
+            "kind": "wrong",
+            "args": {}
+          }
+        ]
       })
-    end.to raise_error(CeleryScript::TypeCheckError)
+    checker  = CeleryScript::Checker.new(tree, test_corpus)
+    actual   = checker.error.message
+    expected = "Body of 'wrong' node contains 'wrong' node"
+    expect(actual).to include(expected)
   end
 end

--- a/spec/lib/celery_script/body_spec.rb
+++ b/spec/lib/celery_script/body_spec.rb
@@ -28,4 +28,14 @@ describe "Body nodes" do
       "node contains `wrong` node"
     )
   end
+
+  it 'disallows leaves in the body field of a node' do
+    expect do
+      CeleryScript::AstNode.new({
+        "kind": "baz",
+        "args": {},
+        "body": ["wrong"]
+      })
+    end.to raise_error(CeleryScript::TypeCheckError)
+  end
 end

--- a/spec/lib/celery_script/body_spec.rb
+++ b/spec/lib/celery_script/body_spec.rb
@@ -24,9 +24,7 @@ describe "Body nodes" do
     })
     checker = CeleryScript::Checker.new(tree, test_corpus)
     expect(checker.valid?).to eq(false)
-    expect(checker.error.message).to include(
-      "node contains 'wrong' node"
-    )
+    expect(checker.error.message).to include("node contains 'wrong' node")
   end
 
   it 'disallows leaves in the body field of a node' do

--- a/spec/lib/celery_script/checker_spec.rb
+++ b/spec/lib/celery_script/checker_spec.rb
@@ -17,7 +17,7 @@ describe CeleryScript::Checker do
       CeleryScript::AstNode.new(hash)
   end
 
-  let (:corpus) { Sequence::Corpus}
+  let (:corpus) { Sequence::Corpus }
 
   let (:checker) { CeleryScript::Checker.new(tree, corpus) }
 
@@ -29,22 +29,21 @@ describe CeleryScript::Checker do
   end
 
   it "handles missing args" do
-    tree.body.first.args.delete(:x)
+    tree.body.first.args[:location].args.delete(:x)
     expect(checker.valid?).to be(false)
     msg = checker.error.message
-    expect(msg).to include("Expected node 'move_absolute' to have a 'x'")
+    expect(msg).to include("Expected node 'coordinate' to have a 'x'")
   end
 
   it "handles unknown args" do
     tree.body.first.args["foo"] = "bar"
     expect(checker.valid?).to be(false)
     msg = checker.error.message
-    expect(msg).to eq("'move_absolute' has unexpected arguments: [:foo]."\
-                      " Allowed arguments: [:x, :y, :z, :speed]")
+    expect(msg).to include("unexpected arguments: [:foo].")
   end
 
   it "handles malformed / wrong type args" do
-    tree.body.first.args[:x] = "WRONG!"
+    tree.body.first.args[:location].args[:x] = "WRONG!"
     expect(checker.valid?).to be(false)
     msg = checker.error.message
     expect(msg).to eq("Expected 'x' to be a node or leaf, but it was neither")
@@ -58,7 +57,8 @@ describe CeleryScript::Checker do
   end
 
   it 'handles wrong leaf types' do
-    hash[:body][0][:args][:x] = "supposed to be a Fixnum"
+    pending("Actually broke?")
+    hash[:body][0][:args][:location]["x"] = "supposed to be a Fixnum"
     result = checker.run
     expect(result.message).to eq("Expected leaf 'x' within 'move_absolute' to"\
                                  " be one of: [Fixnum] but got String")

--- a/spec/lib/celery_script/checker_spec.rb
+++ b/spec/lib/celery_script/checker_spec.rb
@@ -57,10 +57,9 @@ describe CeleryScript::Checker do
   end
 
   it 'handles wrong leaf types' do
-    pending("Actually broke?")
-    hash[:body][0][:args][:location]["x"] = "supposed to be a Fixnum"
+    hash[:body][0][:args][:location][:args][:x] = "supposed to be a Fixnum"
     result = checker.run
-    expect(result.message).to eq("Expected leaf 'x' within 'move_absolute' to"\
+    expect(result.message).to eq("Expected leaf 'x' within 'coordinate' to"\
                                  " be one of: [Fixnum] but got String")
   end
 end

--- a/spec/lib/celery_script/corpus_spec.rb
+++ b/spec/lib/celery_script/corpus_spec.rb
@@ -6,7 +6,7 @@ describe CeleryScript::Corpus do
   it "serializes into JSON" do
       result = JSON.parse(corpus.to_json)
 
-      expect(result["tag"]).to eq(1)
+      expect(result["tag"]).to eq(2)
       expect(result["args"]).to be_kind_of(Array)
       expect(result["nodes"]).to be_kind_of(Array)
       expect(result["nodes"].sample.keys.sort).to eq(["allowed_args",
@@ -19,8 +19,7 @@ describe CeleryScript::Corpus do
   it "Handles message_type validations for version 1" do
     # This test is __ONLY__ relevant for version 1.
     # Change / delete / update as needed.
-    expect(SequenceMigration::Base.latest_version).to eq(1)
-        tree = CeleryScript::AstNode.new({
+    tree = CeleryScript::AstNode.new({
       "kind": "send_message",
       "args": {
         "message": "Hello, world!",
@@ -35,8 +34,7 @@ describe CeleryScript::Corpus do
   it "Handles channel_name validations for version 1" do
     # This test is __ONLY__ relevant for version 1.
     # Change / delete / update as needed.
-    expect(SequenceMigration::Base.latest_version).to eq(1)
-        tree = CeleryScript::AstNode.new({
+    tree = CeleryScript::AstNode.new({
       "kind": "send_message",
       "args": {
         "message": "Hello, world!",

--- a/spec/lib/celery_script/corpus_spec.rb
+++ b/spec/lib/celery_script/corpus_spec.rb
@@ -45,7 +45,8 @@ describe CeleryScript::Corpus do
     })
     check = CeleryScript::Checker.new(bad, Sequence::Corpus)
     expect(check.valid?).to be_falsey
-    binding.pry
+    expect(check.error.message).to include("but got Fixnum")
+    expect(check.error.message).to include("'location' within 'move_absolute'")
   end
 
   it "serializes into JSON" do

--- a/spec/lib/celery_script/corpus_spec.rb
+++ b/spec/lib/celery_script/corpus_spec.rb
@@ -3,6 +3,50 @@ require 'spec_helper'
 describe CeleryScript::Corpus do
   let (:corpus) { Sequence::Corpus }
 
+  it "handles valid move_absolute blocks" do
+    ok1 = CeleryScript::AstNode.new({
+      kind: "move_absolute",
+      args: {
+        location: {
+          kind: "coordinate",
+          args: {
+            x: 1,
+            y: 2,
+            z: 3
+          }
+        },
+        speed: 100
+      }
+    })
+    check1 = CeleryScript::Checker.new(ok1, Sequence::Corpus)
+    expect(check1.valid?).to be_truthy
+
+    ok2 = CeleryScript::AstNode.new({
+      kind: "move_absolute",
+      args: {
+        location: {
+          kind: "tool",
+          args: { tool_id: FactoryGirl.create(:tool).id }
+        },
+        speed: 100
+      }
+    })
+    check2 = CeleryScript::Checker.new(ok2, Sequence::Corpus)
+    expect(check2.valid?).to be_truthy
+  end
+
+  it "kicks back invalid move_absolute nodes" do
+    bad = CeleryScript::AstNode.new({
+      kind: "move_absolute",
+      args: {
+        location: 42,
+        speed: 100
+      }
+    })
+    check = CeleryScript::Checker.new(bad, Sequence::Corpus)
+    expect(check.valid?).to be_falsey
+  end
+
   it "serializes into JSON" do
       result = JSON.parse(corpus.to_json)
 

--- a/spec/lib/celery_script/corpus_spec.rb
+++ b/spec/lib/celery_script/corpus_spec.rb
@@ -16,7 +16,7 @@ describe CeleryScript::Corpus do
                                                      "name"])
   end
 
-  it "Handles error validations for version 1" do
+  it "Handles message_type validations for version 1" do
     # This test is __ONLY__ relevant for version 1.
     # Change / delete / update as needed.
     expect(SequenceMigration::Base.latest_version).to eq(1)
@@ -26,14 +26,30 @@ describe CeleryScript::Corpus do
         "message": "Hello, world!",
         "message_type": "wrong"
       },
+      "body": []
+    })
+    checker = CeleryScript::Checker.new(tree, CeleryScriptSettingsBag::Corpus)
+    expect(checker.error.message).to include("not a valid message_type")
+  end
+
+  it "Handles channel_name validations for version 1" do
+    # This test is __ONLY__ relevant for version 1.
+    # Change / delete / update as needed.
+    expect(SequenceMigration::Base.latest_version).to eq(1)
+        tree = CeleryScript::AstNode.new({
+      "kind": "send_message",
+      "args": {
+        "message": "Hello, world!",
+        "message_type": "fun"
+      },
       "body": [
         {
           "kind": "channel",
-          "args": { "channel_name": "also_wrong" }
+          "args": { "channel_name": "wrong" }
         }
       ]
     })
     checker = CeleryScript::Checker.new(tree, CeleryScriptSettingsBag::Corpus)
-    binding.pry
+    expect(checker.error.message).to include("not a valid channel_name")
   end
 end

--- a/spec/lib/celery_script/corpus_spec.rb
+++ b/spec/lib/celery_script/corpus_spec.rb
@@ -15,4 +15,25 @@ describe CeleryScript::Corpus do
       expect(result["args"].sample.keys.sort).to eq(["allowed_values",
                                                      "name"])
   end
+
+  it "Handles error validations for version 1" do
+    # This test is __ONLY__ relevant for version 1.
+    # Change / delete / update as needed.
+    expect(SequenceMigration::Base.latest_version).to eq(1)
+        tree = CeleryScript::AstNode.new({
+      "kind": "send_message",
+      "args": {
+        "message": "Hello, world!",
+        "message_type": "wrong"
+      },
+      "body": [
+        {
+          "kind": "channel",
+          "args": { "channel_name": "also_wrong" }
+        }
+      ]
+    })
+    checker = CeleryScript::Checker.new(tree, CeleryScriptSettingsBag::Corpus)
+    binding.pry
+  end
 end

--- a/spec/lib/celery_script/corpus_spec.rb
+++ b/spec/lib/celery_script/corpus_spec.rb
@@ -45,6 +45,7 @@ describe CeleryScript::Corpus do
     })
     check = CeleryScript::Checker.new(bad, Sequence::Corpus)
     expect(check.valid?).to be_falsey
+    binding.pry
   end
 
   it "serializes into JSON" do

--- a/spec/lib/sequence_migration_spec.rb
+++ b/spec/lib/sequence_migration_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe SequenceMigration do
   it 'has a latest version' do
-      expect(SequenceMigration::Base.latest_version).to eq(1)
+      expect(SequenceMigration::Base.latest_version).to eq(2)
   end
 end

--- a/spec/mutations/sequences/create_spec.rb
+++ b/spec/mutations/sequences/create_spec.rb
@@ -20,8 +20,7 @@ describe Sequences::Create do
 
   it 'Gives validation errors for malformed AST nodes' do
     move_abs = body.select{ |x| x["kind"] == "move_absolute" }.first
-    binding.pry
-    move_abs["args"]["location"]["x"] = "not a number"
+    move_abs["args"]["location"]["args"]["x"] = "not a number"
     seq = Sequences::Create.run(sequence_params)
     expect(seq.success?).to be(false)
     expect(seq.errors["body"].message).to include("but got String")

--- a/spec/mutations/sequences/create_spec.rb
+++ b/spec/mutations/sequences/create_spec.rb
@@ -19,14 +19,17 @@ describe Sequences::Create do
   end
 
   it 'Gives validation errors for malformed AST nodes' do
-    body.first["args"]["location"]["x"] = "not a number"
+    move_abs = body.select{ |x| x["kind"] == "move_absolute" }.first
+    binding.pry
+    move_abs["args"]["location"]["x"] = "not a number"
     seq = Sequences::Create.run(sequence_params)
     expect(seq.success?).to be(false)
     expect(seq.errors["body"].message).to include("but got String")
   end
 
   it 'Gives validation errors for malformed pin_mode' do
-    body[2]["args"]["pin_mode"] = -9
+    pin_write = body.select{ |x| x["kind"] == "write_pin" }.first
+    pin_write["args"]["pin_mode"] = -9
     seq = Sequences::Create.run(sequence_params)
     expect(seq.success?).to be(false)
     expectation = 'Can not put "-9" into a left hand side (LHS) argument.'
@@ -42,7 +45,7 @@ describe Sequences::Create do
   end
 
   it 'Gives validation errors for malformed LHS' do
-    body[6]["args"]["lhs"] = "xyz"
+    body.select{ |x| x["kind"] == "if_statement" }.first["args"]["lhs"] = "xyz"
     seq = Sequences::Create.run(sequence_params)
     expect(seq.success?).to be(false)
     expected = "Can not put \"xyz\" into a left hand side (LHS) argument."
@@ -50,7 +53,7 @@ describe Sequences::Create do
   end
 
   it 'Gives validation errors for malformed OP' do
-    body[6]["args"]["op"] = "was"
+    body.select{ |x| x["kind"] == "if_statement" }.first["args"]["op"] = "was"
     seq = Sequences::Create.run(sequence_params)
     expect(seq.success?).to be(false)
     expected = "Can not put \"was\" into an operand (OP) argument."

--- a/spec/mutations/sequences/create_spec.rb
+++ b/spec/mutations/sequences/create_spec.rb
@@ -19,7 +19,7 @@ describe Sequences::Create do
   end
 
   it 'Gives validation errors for malformed AST nodes' do
-    body.first["args"]["x"] = "not a number"
+    body.first["args"]["location"]["x"] = "not a number"
     seq = Sequences::Create.run(sequence_params)
     expect(seq.success?).to be(false)
     expect(seq.errors["body"].message).to include("but got String")

--- a/spec/mutations/sequences/migration_from_v_0_or_none_spec.rb
+++ b/spec/mutations/sequences/migration_from_v_0_or_none_spec.rb
@@ -79,7 +79,7 @@ BODY2 = [
           ]
       }
   ]
-describe "Migrate from [0, nil] to 1" do
+describe "Migration from version 0 or nil" do
   let(:user) { FactoryGirl.create(:user) }
   let(:device) { user.device }
   let(:seq1) { FactoryGirl.create(:sequence, device: device, body: BODY1) }
@@ -96,14 +96,14 @@ describe "Migrate from [0, nil] to 1" do
       expected = BODY1.dig(0, "args", "message")
       expect(actual).to eq(expected)
       expect(seq1.body.dig(0, "args", "message_type")).to eq("info")
-      expect(seq1.args["version"]).to eq(1)
+      expect(seq1.args["version"]).to eq(2)
   end
 
   it 'handles `channel` body nodes' do
       Sequences::Migrate.run!(device: device, sequence: seq2)
 
       expect(seq2.body.dig(0, "args", "message_type")).to eq("info")
-      expect(seq2.args["version"]).to eq(1)
+      expect(seq2.args["version"]).to eq(2)
       results = seq2
                   .body
                   .map{|x| x["body"]}

--- a/spec/mutations/sequences/migration_from_v_1_spec.rb
+++ b/spec/mutations/sequences/migration_from_v_1_spec.rb
@@ -29,6 +29,12 @@ describe "Migration from version 0 or nil" do
 
   it 'Updates `move_absolute` nodes' do
       Sequences::Migrate.run!(device: device, sequence: seq)
-      binding.pry
+      nodes = seq.body.select{ |x| x["kind"] == "move_absolute"}
+      args = nodes.map { |x| x["args"].keys }.flatten.uniq
+      expect(args).to_not include("x")
+      expect(args).to_not include("y")
+      expect(args).to_not include("z")
+      expect(args).to include("speed")
+      expect(args).to include("location")
   end
 end

--- a/spec/mutations/sequences/migration_from_v_1_spec.rb
+++ b/spec/mutations/sequences/migration_from_v_1_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+# Real world examples in use as of 19 DEC 16
+BODY = [
+ {"kind"=>"move_absolute", "args"=>{"x"=>0, "y"=>0, "z"=>0, "speed"=>100}},
+ {"kind"=>"move_absolute", "args"=>{"x"=>0, "y"=>0, "z"=>0, "speed"=>200}},
+ {"kind"=>"move_absolute", "args"=>{"x"=>0, "y"=>1000, "z"=>0, "speed"=>200}},
+ {"kind"=>"move_absolute", "args"=>{"x"=>10, "y"=>50, "z"=>15, "speed"=>100}},
+ {"kind"=>"move_absolute", "args"=>{"x"=>0, "y"=>0, "z"=>0, "speed"=>100}},
+ {"kind"=>"move_absolute", "args"=>{"x"=>0, "y"=>0, "z"=>0, "speed"=>100}},
+ {"kind"=>"move_absolute", "args"=>{"x"=>0, "y"=>0, "z"=>0, "speed"=>200}},
+ {"kind"=>"move_absolute", "args"=>{"x"=>0, "y"=>1000, "z"=>0, "speed"=>200}},
+ {"kind"=>"execute", "args"=>{"sub_sequence_id"=>5}},
+ {"kind"=>"execute", "args"=>{"sub_sequence_id"=>6}},
+ {"kind"=>"execute", "args"=>{"sub_sequence_id"=>5}},
+ {"kind"=>"move_relative", "args"=>{"x"=>49, "y"=>10, "z"=>10, "speed"=>100}},
+ {"kind"=>"move_relative", "args"=>{"x"=>0, "y"=>0, "z"=>0, "speed"=>100}},
+ {"kind"=>"wait", "args"=>{"milliseconds"=>0}},
+ {"kind"=>"wait", "args"=>{"milliseconds"=>1500}},
+ {"kind"=>"wait", "args"=>{"milliseconds"=>1500}},
+ {"kind"=>"execute", "args"=>{"sub_sequence_id"=>26}},
+ {"kind"=>"execute", "args"=>{"sub_sequence_id"=>32}},
+ {"kind"=>"execute", "args"=>{"sub_sequence_id"=>32}},
+]
+
+describe "Migration from version 0 or nil" do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:device) { user.device }
+  let(:seq) { FactoryGirl.create(:sequence, device: device, body: BODY) }
+
+  it 'Updates `move_absolute` nodes' do
+      Sequences::Migrate.run!(device: device, sequence: seq)
+      binding.pry
+  end
+end

--- a/spec/stuff.rb
+++ b/spec/stuff.rb
@@ -4,6 +4,7 @@ module Helpers
   # Create a VALID fake sequence.body for a particular user. Creates a fake
   # subsequence in the DB when called.
   def sequence_body_for(input)
+    user ||= FactoryGirl.create(:user)
     body = JSON.parse(AST_FIXTURE)["body"]
     case input
     when User; id = FactoryGirl.create(:sequence, device: user.device).id

--- a/spec/stuff.rb
+++ b/spec/stuff.rb
@@ -10,8 +10,11 @@ module Helpers
     when Sequence; id = input.id
     else; raise "?????"
     end
+    tool_id = FactoryGirl.create(:tool, device: user.device).id
     body.map! do |node|
-      has_subseq = node.dig("args", "sub_sequence_id");
+      has_subseq = node.dig("args", "sub_sequence_id")
+      has_tool   = node.dig("args", "location", "args", "tool_id")
+      node["args"]["location"]["args"]["tool_id"] = tool_id if has_tool
       node["args"]["sub_sequence_id"] = id if has_subseq
       node
     end


### PR DESCRIPTION
# What's New?

 * Fixed a bug where `move_abs` would not validate a node/step.
 * Added the ability to `move_absolute` to a `tool` location.
 * Tons more tests for all the use cases that can arise from the feature above.
 * Migration that upgrades existing sequences to new format without breaking backwards compatibility.
 